### PR TITLE
fix(en nav is-active): fixes an issue where the is-active highlighting was only working in JS

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -34,7 +34,7 @@ layout: skeleton
             {%- comment -%} <!-- if there is no id we dont add it to the menu --> {%- endcomment -%}
             {% continue %}
             {%- endunless  -%}
-            <a class="navbar-item menu__navbar-items" id="navbar-item-{{forloop.index0}}" href="/{%-if page.lang == 'en'-%}en{%-endif-%}#{{id}}">
+            <a class="navbar-item menu__navbar-items" id="navbar-item-{{forloop.index0}}" href="{%-if page.lang == 'en'-%}/en/#{{id}}{%-else-%}/#{{id}}{%-endif-%}">
               {{text}}
             </a>
             {%- endfor -%}


### PR DESCRIPTION
The syntax for the anchor has to be /en/#idname. Due to the missing slash before the hash the page
got loaded again and again and again

fix #45