### PR TITLE
Fix footer spacing

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -353,24 +353,24 @@ layout: skeleton
         <p>
           {{site.data.content.meta.footer.byline[page.lang]}}
         </p>
+        <a href="{%- if page.lang == 'de' -%}https://www.technologiestiftung-berlin.de{%- else -%}https://www.technologiestiftung-berlin.de/en/home/{%- endif -%}">
+          <figure class="image is-128x128">
+            <img src="/assets/img/tsb.svg" alt="logo" class="">
+          </figure>
+        </a>
       </div>
-      <a href="{%- if page.lang == 'de' -%}https://www.technologiestiftung-berlin.de{%- else -%}https://www.technologiestiftung-berlin.de/en/home/{%- endif -%}">
-        <figure class="image is-128x128">
-          <img src="/assets/img/tsb.svg" alt="logo" class="">
-        </figure>
-      </a>
     </div>
     <div class="column">
       <div class="content">
         <p>
           {{site.data.content.meta.footer.executeedline[page.lang]}}
         </p>
+        <a href="{%- if page.lang == 'de' -%}https://www.citylab-berlin.org/{%- else -%}https://www.citylab-berlin.org/index_en{%- endif -%}">
+          <figure class="image is-128x128">
+            <img src="/assets/img/citylab-logo.svg" alt="logo" class="">
+          </figure>
+        </a>
       </div>
-      <a href="{%- if page.lang == 'de' -%}https://www.citylab-berlin.org/{%- else -%}https://www.citylab-berlin.org/index_en{%- endif -%}">
-        <figure class="image is-128x128">
-          <img src="/assets/img/citylab-logo.svg" alt="logo" class="">
-        </figure>
-      </a>
     </div>
       <div class="column">
         <div class="content">

--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -65,7 +65,7 @@ footer .content p:not(:last-child) {
   margin-bottom: 0;
 }
 
-footer .content figure:not(:first-child) {
+footer .content figure {
   margin-top: 0.5rem;
   margin-left: 0;
 }


### PR DESCRIPTION
- moves TSB and CityLAB logos into `.content` wrapper
- applies consistent padding to logos