### PR TITLE
feat(mobile menu): close mobile menu after click

### DIFF
--- a/src/assets/ts/__tests__/navbar.test.ts
+++ b/src/assets/ts/__tests__/navbar.test.ts
@@ -1,5 +1,10 @@
-import { toggleIsActive } from "../lib/navbar";
-import { getByText, fireEvent, getAllByTestId } from "@testing-library/dom";
+import { toggleIsActive, closeMenuAfterClick } from "../lib/navbar";
+import {
+  getByText,
+  fireEvent,
+  getAllByTestId,
+  getByTestId
+} from "@testing-library/dom";
 
 afterEach(() => {
   document.getElementsByTagName("html")[0].innerHTML = "";
@@ -7,6 +12,13 @@ afterEach(() => {
 
 function setupMenu(): HTMLDivElement {
   const menu = document.createElement("div");
+  const checkBox = document.createElement("input");
+  checkBox.type = "checkbox";
+  checkBox.id = "navbar-burger-toggle";
+  checkBox.checked = false;
+  checkBox.setAttribute("data-testid", "checkbox");
+  menu.appendChild(checkBox);
+
   const items = [1, 2, 3, 4].map(i => {
     const anchor = document.createElement("a");
     anchor.classList.add("menu__navbar-items", "navbar-item");
@@ -23,6 +35,33 @@ function setupMenu(): HTMLDivElement {
 }
 
 describe("navbar", () => {
+  test("should uncheck checkbox after click", () => {
+    const menu = setupMenu();
+    const checkBox = getByTestId(menu, /checkbox/) as HTMLInputElement;
+    checkBox.checked = true;
+    const allAnchros = getAllByTestId(menu, /test-\d/);
+    closeMenuAfterClick();
+    fireEvent.click(allAnchros[0]);
+    expect(checkBox.checked).toBe(false);
+  });
+  test("should throw due to missing navbar items", () => {
+    const menu = setupMenu();
+    const allAnchros = getAllByTestId(menu, /test-\d/);
+    allAnchros.forEach(item => {
+      item.remove();
+    });
+    expect(() => {
+      closeMenuAfterClick();
+    }).toThrow();
+  });
+  test("should throw due to missing checkbox items", () => {
+    const menu = setupMenu();
+    const checkBox = getByTestId(menu, /checkbox/) as HTMLInputElement;
+    checkBox.remove();
+    expect(() => {
+      closeMenuAfterClick();
+    }).toThrow();
+  });
   test("should add class is-active to clicked item", () => {
     const menu = setupMenu();
     toggleIsActive();

--- a/src/assets/ts/index.ts
+++ b/src/assets/ts/index.ts
@@ -1,21 +1,7 @@
-import { toggleIsActive } from "./lib/navbar";
+import { toggleIsActive, closeMenuAfterClick } from "./lib/navbar";
 
 // import { add } from "./lib/stub";
 document.addEventListener("DOMContentLoaded", function() {
   toggleIsActive();
-  // const navItems = document.querySelectorAll(".menu__navbar-items");
-  // if (navItems !== null && navItems.length > 0) {
-  //   // loop all items and remove is-active
-  //   // only add to clicked
-  //   navItems.forEach(item => {
-  //     item.addEventListener("click", () => {
-  //       for (const elem of Array.from(navItems)) {
-  //         elem.classList.remove("is-active");
-  //       }
-  //       item.classList.add("is-active");
-  //     });
-  //   });
-  // } else {
-  //   throw new Error("Could not find navbar elements");
-  // }
+  closeMenuAfterClick();
 });

--- a/src/assets/ts/lib/navbar.ts
+++ b/src/assets/ts/lib/navbar.ts
@@ -15,3 +15,21 @@ export function toggleIsActive(): void {
     throw new Error("Could not find navbar elements");
   }
 }
+
+export function closeMenuAfterClick(): void {
+  const navBarItems = document.querySelectorAll(".navbar-item");
+  const checkBox: HTMLInputElement | null = document.querySelector(
+    "#navbar-burger-toggle"
+  );
+  if (navBarItems === null || navBarItems.length === 0) {
+    throw new Error("Could not find navbar items");
+  }
+  if (checkBox === null) {
+    throw new Error("Could not find checkbox items");
+  }
+  navBarItems.forEach(item => {
+    item.addEventListener("click", () => {
+      checkBox.checked = false;
+    });
+  });
+}


### PR DESCRIPTION
Adds a JS function that sets the checkbox back to unchecked after a click on `.navbar-item`.
+ Tests
close #57 